### PR TITLE
Add DISPATCH_PROVISIONING_MESSAGE for com.google.android.pixel.setupwizard to privapp-permissions

### DIFF
--- a/list/core/PixelSetupWizard/PixelSetupWizard.xml
+++ b/list/core/PixelSetupWizard/PixelSetupWizard.xml
@@ -1,5 +1,6 @@
 <privapp-permissions package="com.google.android.pixel.setupwizard">
         <permission name="android.permission.CHANGE_CONFIGURATION" />
+        <permission name="android.permission.DISPATCH_PROVISIONING_MESSAGE" />
         <permission name="android.permission.GET_ACCOUNTS_PRIVILEGED" />
         <permission name="android.permission.MANAGE_USERS" />
         <permission name="android.permission.STATUS_BAR" />

--- a/system/etc/permissions/privapp-permissions-LiteGapps.xml
+++ b/system/etc/permissions/privapp-permissions-LiteGapps.xml
@@ -282,6 +282,7 @@ It allows additional grants on top of privapp-permissions-platform.xml
     </privapp-permissions>
     <privapp-permissions package="com.google.android.pixel.setupwizard">
         <permission name="android.permission.CHANGE_CONFIGURATION" />
+        <permission name="android.permission.DISPATCH_PROVISIONING_MESSAGE" />
         <permission name="android.permission.GET_ACCOUNTS_PRIVILEGED" />
         <permission name="android.permission.MANAGE_USERS" />
         <permission name="android.permission.STATUS_BAR" />


### PR DESCRIPTION
```
W PackageManager: Privileged permission android.permission.DISPATCH_PROVISIONING_MESSAGE for package com.google.android.pixel.setupwizard (/system_ext/priv-app/PixelSetupWizard) not in privapp-permissions allowlist
```